### PR TITLE
Fix SourceInstallServiceOSGiTest for new Maven support

### DIFF
--- a/ch.vorburger.osgi.gradle.test/src/test/java/ch/vorburger/osgi/gradle/test/SourceInstallServiceOSGiTest.java
+++ b/ch.vorburger.osgi.gradle.test/src/test/java/ch/vorburger/osgi/gradle/test/SourceInstallServiceOSGiTest.java
@@ -83,6 +83,7 @@ public class SourceInstallServiceOSGiTest implements AutoCloseable {
                 mavenBundle("com.google.guava", "guava", "17.0"),
                 wrappedBundle(maven("org.awaitility", "awaitility", "2.0.0")),
                 bundle("file:../org.gradle.tooling.osgi/build/libs/org.gradle.tooling.osgi-3.3.jar"),
+                wrappedBundle(maven("org.apache.maven.shared", "maven-invoker", "3.0.0")),
                 bundle("file:../ch.vorburger.osgi.gradle/build/libs/ch.vorburger.osgi.gradle-1.0.0-SNAPSHOT.jar"),
                 bundle("file:../ch.vorburger.osgi.gradle.test.bundle.api/build/libs/ch.vorburger.osgi.gradle.test.bundle.api-1.0.0-SNAPSHOT.jar"),
                 junitBundles());


### PR DESCRIPTION
This just makes the IT pass again (it was broken following @edewit's
contribution).  The IT still doesn't actually cover Maven, only Gradle;
that's OK, for now.